### PR TITLE
odoo-ocb : Changer le fichier setup_dev.py pour l'automatisation

### DIFF
--- a/setup/setup_dev.py
+++ b/setup/setup_dev.py
@@ -119,7 +119,7 @@ def setup_deps_debian(git_dir):
     debian_control = open(debian_control_path).read()
     debs = re.findall('python-[0-9a-z]+',debian_control)
     debs += ["postgresql"]
-    proc = subprocess.Popen(['sudo','apt-get','install'] + debs, stdin=open('/dev/tty'))
+    proc = subprocess.Popen(['sudo','apt-get', '-y', 'install'] + debs)
     proc.communicate()
 
 def cmd_setup_deps():


### PR DESCRIPTION
La ligne 122 du fichier odoo-ocb/setup/setup_dev.py empeche l'automatisation complete
de l'installation du repertoire odof10.

Apres plusieurs tests, je propose le changement de :
subprocess.Popen(['sudo','apt-get','install'] + debs, stdin=open('/dev/tty'))

par :
subprocess.Popen(['sudo','apt-get','-y','install'] + debs)

Note : Ce changement n'affecte pas l'installation manuelle

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
