### PR TITLE
sale : T2796 - [FIX] Arrondi du montant des factures d'acompte.

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -78,7 +78,9 @@ class SaleAdvancePaymentInv(models.TransientModel):
             raise UserError(_('The value of the down payment amount must be positive.'))
         context = {'lang': order.partner_id.lang}
         if self.advance_payment_method == 'percentage':
-            amount = order.amount_untaxed * self.amount / 100
+            # OF Modification OpenFire
+            amount = round(order.amount_untaxed * self.amount / 100, 2)
+            # OF Fin modification OpenFire
             name = _("Down payment of %s%%") % (self.amount,)
         else:
             amount = self.amount


### PR DESCRIPTION
Lors de la génération d'une facture d'acompte en pourcentage, la précédente modification (T2796) arrondissait le montant sur la ligne de commande mais pas sur la ligne de facture.
Cela pouvait provoquer des données comptables erronées à la validation de la facture finale.
