### PR TITLE
[FIX] base: reason json payload using get_data

### DIFF
--- a/doc/cla/individual/kirca.md
+++ b/doc/cla/individual/kirca.md
@@ -9,3 +9,4 @@ declaration.
 Signed,
 
 Kiril Vangelovski kiril@hacbee.com https://github.com/kirca
+Kiril Vangelovski kiril@lambda-is.com https://github.com/kirca

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -633,7 +633,7 @@ class JsonRequest(WebRequest):
             request = self.session.pop('jsonp_request_%s' % (request_id,), '{}')
         else:
             # regular jsonrpc2
-            request = self.httprequest.stream.read()
+            request = self.httprequest.get_data().decode(self.httprequest.charset)
 
         # Read POST content or POST Form Data named "request"
         try:


### PR DESCRIPTION
Replace `httprequest.stream.read()` by `httprequest.get_data()` so the payload content remains available: get_data stores the request body (by default) so it remains available for alternative processing or checks (MAC checks for webhook validations for instance). With `stream.read()`, once the data is read if it's not stored separately it is lost.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
